### PR TITLE
Updated port numbers in the docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,6 @@ services:
     apache:
           build: . 
           ports:
-             - "8080:80"
+             - "80:80"
           volumes:
              - ./public_html/:/usr/local/apache2/htdocs/


### PR DESCRIPTION
Updated port numbers to solve port mapping error when running built image in azure cloud
Error solved:
Port mapping is not supported with ACI, cannot map port 8080 to 80 for container sad-volhard